### PR TITLE
fix: measure content height on layout change

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -155,8 +155,13 @@ export default class Collapsible extends Component {
     ) {
       return;
     }
-    this.state.height.setValue(contentHeight);
-    this.setState({ contentHeight });
+
+    this._measureContent(contentHeight => {
+      this.setState({
+        contentHeight,
+        height: new Animated.Value(contentHeight)
+      });
+    });
   };
 
   render() {


### PR DESCRIPTION
When you were with collapsible opened (`state.collapsed = false`) and children changes it's height, Collapsible component was breaking the layout.